### PR TITLE
feat: add Dockerfile to support using over tcp rpc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /app
 
 COPY --from=builder /app/target/release/rime_ls /app
 
-EXPOSE 9527
+EXPOSE 9257
 
 CMD ["/app/rime_ls","--listen","0.0.0.0:9257"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust as builder
+
+RUN apt update && apt install -y clang librime-dev
+
+WORKDIR /app
+
+COPY . .
+
+RUN cargo build --release
+
+FROM debian:12
+
+RUN apt update && apt install -y librime-dev
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/rime_ls /app
+
+EXPOSE 9527
+
+CMD ["/app/rime_ls","--listen","0.0.0.0:9257"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  rime-ls:
+    restart: always
+    build: .
+    ports:
+      - 9257:9257
+    volumes:
+      # mount your rime user data
+      - /root/.config/my_rime:/root/.local/share/rime-ls


### PR DESCRIPTION
提供了 Dockerfile 和 docker-compose 文件，可以一键启动 rime-ls 的 tcp 模式，并把 rime 的 user data 挂载到容器中。