### PR TITLE
feat: impl position encoding selection

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -12,7 +12,7 @@ use crate::config::{apply_setting, Config, Settings};
 use crate::consts::{trigger_ptn, NT_RE};
 use crate::input::{Input, InputResult, InputState};
 use crate::rime::{Candidate, Rime, RimeError, RimeResponse};
-use crate::utils;
+use crate::utils::{self, Encoding};
 
 pub struct Backend {
     client: Client,
@@ -20,6 +20,7 @@ pub struct Backend {
     state: DashMap<String, Option<InputState>>,
     config: RwLock<Config>,
     regex: RwLock<Regex>,
+    encoding: RwLock<Encoding>,
 }
 
 impl Backend {
@@ -30,6 +31,7 @@ impl Backend {
             state: DashMap::new(),
             config: RwLock::new(Config::default()),
             regex: RwLock::new(NT_RE.clone()),
+            encoding: RwLock::new(Encoding::default()),
         }
     }
 
@@ -139,11 +141,12 @@ impl Backend {
     async fn get_completions(&self, uri: Url, position: Position) -> Option<CompletionList> {
         // get new input
         let rope = self.documents.get(uri.as_str())?;
+        let encoding = self.encoding.read().await.clone();
         let line_begin = {
             let line_pos = Position::new(position.line, 0);
-            utils::position_to_offset(&rope, line_pos)?
+            utils::position_to_offset(&rope, line_pos, encoding)?
         };
-        let curr_char = utils::position_to_offset(&rope, position)?;
+        let curr_char = utils::position_to_offset(&rope, position, encoding)?;
         let new_input = {
             let re = self.regex.read().await;
             let has_trigger = !self.config.read().await.trigger_characters.is_empty();
@@ -297,6 +300,14 @@ impl LanguageServer for Backend {
             triggers.extend_from_slice(user_triggers);
             triggers
         };
+
+        let encoding_options = params
+            .capabilities
+            .general
+            .and_then(|g| g.position_encodings);
+        let encoding = utils::select_encoding(encoding_options);
+        *self.encoding.write().await = encoding;
+
         // return
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
@@ -304,6 +315,7 @@ impl LanguageServer for Backend {
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
             capabilities: ServerCapabilities {
+                position_encoding: Some(PositionEncodingKind::new(encoding.as_str())),
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
                     TextDocumentSyncKind::INCREMENTAL,
                 )),
@@ -344,6 +356,7 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let encoding = self.encoding.read().await.clone();
         let url = params.text_document.uri;
         if let Some(mut rope) = self.documents.get_mut(url.as_str()) {
             for change in params.content_changes {
@@ -351,8 +364,8 @@ impl LanguageServer for Backend {
                 match range {
                     // incremental change
                     Some(Range { start, end }) => {
-                        let s = utils::position_to_offset(&rope, start);
-                        let e = utils::position_to_offset(&rope, end);
+                        let s = utils::position_to_offset(&rope, start, encoding);
+                        let e = utils::position_to_offset(&rope, end, encoding);
                         if let (Some(s), Some(e)) = (s, e) {
                             rope.remove(s..e);
                             rope.insert(s, &text);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,9 +4,10 @@ use tower_lsp::lsp_types::{Position, PositionEncodingKind};
 
 use crate::consts::AUTO_TRIGGER_RE;
 
-#[derive(Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub enum Encoding {
     UTF8,
+    #[default]
     UTF16,
     UTF32,
 }
@@ -21,22 +22,16 @@ impl Encoding {
     }
 }
 
-impl Default for Encoding {
-    fn default() -> Self {
-        Encoding::UTF16
-    }
-}
-
 pub fn select_encoding(options: Option<Vec<PositionEncodingKind>>) -> Encoding {
     match options {
-        // prefer utf-32 because of no conversion cost
+        // we prefer utf-32 here because there are no conversion costs
         Some(v) if v.contains(&PositionEncodingKind::new("utf-32")) => Encoding::UTF32,
         Some(v) if v.contains(&PositionEncodingKind::new("utf-8")) => Encoding::UTF8,
         _ => Encoding::default(),
     }
 }
 
-/// UTF-16 Position -> char index
+/// UTF-8/16/32 Position -> char index
 pub fn position_to_offset(rope: &Rope, position: Position, encoding: Encoding) -> Option<usize> {
     let (line, col) = (position.line as usize, position.character as usize);
     // position is at the end of rope
@@ -55,7 +50,7 @@ pub fn position_to_offset(rope: &Rope, position: Position, encoding: Encoding) -
     })
 }
 
-/// char index -> UTF-16 Position
+/// char index -> UTF-8/16/32 Position
 pub fn offset_to_position(rope: &Rope, offset: usize, encoding: Encoding) -> Option<Position> {
     let line = rope.try_char_to_line(offset).ok()?;
     let col_offset = offset - rope.try_line_to_char(line).ok()?;


### PR DESCRIPTION
As recent versions of neovim had bugs in LSP position encoding UTF-16 or UTF-32 (see https://github.com/neovim/neovim/issues/30692), 
I try to implement position encoding selection at server side (as described in [LSP Spec 3.17](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments)), 
so that rime-ls can use UTF-8 to communicate with neovim to bypass this issue.